### PR TITLE
Generic Error Handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "nodemon --watch 'src/**/*' -e ts --exec ts-node ./src/server.ts",
+    "start": "nodemon --watch src/**/* -e ts --exec ts-node ./src/server.ts",
     "lint": "eslint ./src/**/*.ts",
     "lint-fix": "yarn lint --fix",
     "test": "jest"

--- a/src/middleware/error-handler.middleware.ts
+++ b/src/middleware/error-handler.middleware.ts
@@ -1,0 +1,12 @@
+import { Context, Next, Middleware } from 'koa'
+
+const errorHandler: Middleware = async (ctx: Context, next: Next) => {
+    try {
+        await next()
+    } catch (error) {
+        ctx.status = error.statusCode || error.status || 500
+        ctx.body = { error: error.message }
+    }
+}
+
+export default errorHandler

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import * as Koa from 'koa'
 import * as Router from 'koa-router'
 import * as bodyParser from 'koa-body'
+import errorHandler from './middleware/error-handler.middleware'
 import * as KoaLogger from 'koa-logger-winston'
 import logger from './util/logger.util'
 
@@ -8,11 +9,16 @@ const app = new Koa()
 const router = new Router()
 const port = 8000
 
-// Keep this as early as possible, takes care of parsing JSON
+// Keep these as early as possible, takes care of parsing JSON, logging, and error handling
 app.use(bodyParser())
 app.use(KoaLogger(logger))
+app.use(errorHandler)
 
-router.get('/*', async ctx => {
+// TODO Extract these routes somewhere that makes more sense
+router.get('/error', async () => {
+    throw new Error('This is what will happen when there is a problem!')
+})
+router.get('/', async ctx => {
     logger.info(`A route was called! It looked like ${ctx.path}!`)
     ctx.body = 'This will be the zombie roleplaying game API!'
 })


### PR DESCRIPTION
### Summary
This PR wraps the routes with a generic error handling middleware, so any uncaught errors will generate a predictable response through the API.

If accepted, this PR will:

- Implement an error handling middleware that will catch any errors that happen in my routes and return it to the API consumer with a body of the form `{ error: <errorMessage> }` and a default status code of 500.
- Create an example of the middleware in action at `/error`.
- Fix a small bug with my nodemon configuration that was keeping it from actually restarting when I made file changes.

### To Test

1. Run `yarn && yarn start`
1. Visit http://localhost:8000/error in your browser or perform a GET request against the same URL through a tool like [Postman](https://www.postman.com/) or [Insomnia](https://insomnia.rest/)

### Suggested Reading

- [KoaJS Error Handling Documentation](https://github.com/koajs/koa/blob/master/docs/error-handling.md)