### PR TITLE
Add koa2-cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "koa-combine-routers": "^4.0.2",
     "koa-logger-winston": "^0.0.2",
     "koa-router": "^8.0.8",
+    "koa2-cors": "^2.0.6",
     "mongoose": "^5.9.5",
     "winston": "^3.2.1"
   },
@@ -39,6 +40,7 @@
     "@types/koa": "^2.11.2",
     "@types/koa-logger-winston": "^0.0.2",
     "@types/koa-router": "^7.4.0",
+    "@types/koa2-cors": "^2.0.1",
     "@types/mongoose": "^5.7.7",
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import * as Koa from 'koa'
 import * as bodyParser from 'koa-body'
+import * as cors from 'koa2-cors'
 import errorHandler from './middleware/error-handler.middleware'
 import * as KoaLogger from 'koa-logger-winston'
 import router from './routes'
@@ -14,6 +15,7 @@ async function runServer(): Promise<void> {
     const port = env.port || 8000
 
     // Keep these as early as possible, takes care of parsing JSON, logging, and error handling
+    app.use(cors())
     app.use(bodyParser())
     app.use(KoaLogger(logger))
     app.use(errorHandler)

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,6 +522,13 @@
   dependencies:
     "@types/koa" "*"
 
+"@types/koa2-cors@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/koa2-cors/-/koa2-cors-2.0.1.tgz#76a635cadc9c10e9d29a209fa2db28529dfc765a"
+  integrity sha512-8DaO8CkGJGAVWPeODHeGW6T9grKunnfAg0LAyayMrqP/ggPTiHxwrvrk7UJ+NNZ7aQo4Cn0fHSMKhucj+PcquA==
+  dependencies:
+    "@types/koa" "*"
+
 "@types/koa@*", "@types/koa@^2.11.2":
   version "2.11.2"
   resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.11.2.tgz#0595656a59ff13ca97edf6dde7da1e5319651f9b"
@@ -3273,6 +3280,11 @@ koa-router@^8.0.8:
     methods "^1.1.2"
     path-to-regexp "1.x"
     urijs "^1.19.2"
+
+koa2-cors@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/koa2-cors/-/koa2-cors-2.0.6.tgz#9ad23df3a0b9bb84530b46f5944f3fb576086554"
+  integrity sha512-JRCcSM4lamM+8kvKGDKlesYk2ASrmSTczDtGUnIadqMgnHU4Ct5Gw7Bxt3w3m6d6dy3WN0PU4oMP43HbddDEWg==
 
 koa@^2.11.0:
   version "2.11.0"


### PR DESCRIPTION
### Summary
This PR implements [koa2-cors](https://www.npmjs.com/package/koa2-cors) so the UI can talk to the server.

If accepted, this PR will:

- Add koa2-cors to this server so that the UI is open to Cross Origin Resource Sharing

### To Test

1. Run `yarn && yarn start`.
1. Clone the other repo, [zombie-roleplaying-ui](https://github.com/ahoopes16/zombie-roleplaying-ui) and run `yarn && yarn start` in there.
1. Download [MongoDB](https://www.mongodb.com/) and start up a local instance of that.
1. Create a new encounter using the form there - if it works, koa2-cors is doing its job!

### Related PRs

- https://github.com/ahoopes16/zombie-roleplaying-ui/pull/3

### Suggested Reading

- [koa2-cors](https://www.npmjs.com/package/koa2-cors)
- [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
