### PR TITLE
LWD-23: Weapons Route for Listing All Weapons

### DIFF
--- a/src/controllers/weapon.controller.ts
+++ b/src/controllers/weapon.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Response, Route, SuccessResponse } from 'tsoa'
+import { Body, Controller, Get, Post, Response, Route, SuccessResponse } from 'tsoa'
 import { Weapon, WeaponCreationParams } from '../models/weapon.model'
 import { WeaponService } from '../services/weapon.service'
 import { SuccessResponseJSON, ErrorResponseJSON } from '../types/Response.type'
@@ -10,6 +10,18 @@ export class WeaponController extends Controller {
     constructor(service = new WeaponService()) {
         super()
         this.service = service
+    }
+
+    /**
+     * Get a list of all weapons.
+     * Currently there is no pagination or limits implemented.
+     */
+    @SuccessResponse(200, 'Success')
+    @Response<ErrorResponseJSON>(500, 'Internal Server Error')
+    @Get()
+    public async getWeapons(): Promise<SuccessResponseJSON<Weapon[]>> {
+        this.setStatus(200)
+        return { result: await this.service.listWeapons() }
     }
 
     /**

--- a/src/services/weapon.service.ts
+++ b/src/services/weapon.service.ts
@@ -9,6 +9,10 @@ export class WeaponService {
         this.model = model
     }
 
+    public listWeapons(): Promise<Array<Weapon & Document>> {
+        return this.model.find().exec()
+    }
+
     public async createWeapon(weaponParams: WeaponCreationParams): Promise<Weapon & Document> {
         await this.validateNameDoesNotExist(weaponParams)
         return this.model.create(weaponParams)

--- a/test/weapons/weapon.controller.spec.ts
+++ b/test/weapons/weapon.controller.spec.ts
@@ -1,5 +1,6 @@
 import { WeaponController } from '../../src/controllers/weapon.controller'
-import EncounterModel, { WeaponCreationParams } from '../../src/models/weapon.model'
+import WeaponModel, { WeaponCreationParams } from '../../src/models/weapon.model'
+import { createFakeWeapon } from '../helpers/weapon.helper'
 import DBConnector from '../../src/database'
 import env from '../../src/environment'
 import * as mongoose from 'mongoose'
@@ -12,14 +13,52 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-    await EncounterModel().deleteMany({})
+    await WeaponModel().deleteMany({})
 })
 
 afterAll(async () => {
     await mongoose.disconnect()
 })
 
+const model = WeaponModel()
+
 describe('weapon controller', () => {
+    describe('getWeapons', () => {
+        test('returns empty array if there are no encounters', async () => {
+            const controller = new WeaponController()
+
+            const actual = await controller.getWeapons()
+
+            expect(actual.result).toBeDefined()
+            expect(actual.result.length).toBe(0)
+        })
+
+        test('returns array of encounters inside result', async () => {
+            const controller = new WeaponController()
+            const weaponOneParams: WeaponCreationParams = {
+                name: `Name_${Math.random()}`,
+                description: `Description_${Math.random()}`,
+                attackDieCount: 2,
+                attackDieSides: 10,
+            }
+            const weaponTwoParams: WeaponCreationParams = {
+                name: `Name_${Math.random()}`,
+                description: `Description_${Math.random()}`,
+                attackDieCount: 3,
+                attackDieSides: 12,
+            }
+            const weaponOne = await createFakeWeapon(model, weaponOneParams)
+            const weaponTwo = await createFakeWeapon(model, weaponTwoParams)
+
+            const actual = await controller.getWeapons()
+
+            expect(actual.result).toBeDefined()
+            expect(actual.result.length).toBe(2)
+            expect(actual.result.find(weapon => weapon.name === weaponOne.name)).toBeTruthy()
+            expect(actual.result.find(weapon => weapon.name === weaponTwo.name)).toBeTruthy()
+        })
+    })
+
     describe('postWeapon', () => {
         test('returns created weapon inside result', async () => {
             const expected: WeaponCreationParams = {

--- a/test/weapons/weapon.service.spec.ts
+++ b/test/weapons/weapon.service.spec.ts
@@ -28,6 +28,33 @@ const nameExistsError = (name: string): Boom.Boom => {
 }
 
 describe('weapon service', () => {
+    describe('listWeapons', () => {
+        test('happy path - returns list of weapons', async () => {
+            const service = new WeaponService()
+            const weaponOneParams: WeaponCreationParams = {
+                name: `Name_${Math.random()}`,
+                description: `Description_${Math.random()}`,
+                attackDieCount: 2,
+                attackDieSides: 10,
+            }
+            const weaponTwoParams: WeaponCreationParams = {
+                name: `Name_${Math.random()}`,
+                description: `Description_${Math.random()}`,
+                attackDieCount: 3,
+                attackDieSides: 12,
+            }
+            const weaponOne = await createFakeWeapon(model, weaponOneParams)
+            const weaponTwo = await createFakeWeapon(model, weaponTwoParams)
+
+            const actual = await service.listWeapons()
+
+            expect(actual).toBeDefined()
+            expect(actual.length).toBe(2)
+            expect(actual.find(weapon => weapon.name === weaponOne.name)).toBeTruthy()
+            expect(actual.find(weapon => weapon.name === weaponTwo.name)).toBeTruthy()
+        })
+    })
+
     describe('createWeapon', () => {
         test('happy path - returns created weapon', async () => {
             const service = new WeaponService()


### PR DESCRIPTION
### Summary
This PR is to create a route for listing all weapons in the database.

If accepted, this PR will:

- Create a route to list all weapons currently in the database

### To Test

1. `yarn start`
1. Hit http://localhost:8000/v1/weapons
   1. If you have any weapons in the database, all of them should be returned in the `result`
   1. If you have no weapons in the database, `result` should be an empty array
1. You should be able to import `swagger.json` from the `tsoa/` directory into Postman and get access to this route through that easily.