### PR TITLE
DELETE Specific Weapon

### DIFF
--- a/src/controllers/weapon.controller.ts
+++ b/src/controllers/weapon.controller.ts
@@ -59,6 +59,10 @@ export class WeaponController extends Controller {
      * It will be removed permanently - you won't be able to get it back!
      * @param weaponId Mongo Object ID of the desired weapon.
      */
+    @SuccessResponse(200, 'Success')
+    @Response<ErrorResponseJSON>(400, 'Validation Failed')
+    @Response<ErrorResponseJSON>(404, 'Weapon Not Found')
+    @Response<ErrorResponseJSON>(500, 'Internal Server Error')
     @Delete('{weaponId}')
     public async deleteWeapon(@Path() weaponId: string): Promise<any> {
         this.setStatus(200)

--- a/src/controllers/weapon.controller.ts
+++ b/src/controllers/weapon.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Path, Post, Response, Route, SuccessResponse } from 'tsoa'
+import { Body, Controller, Delete, Get, Path, Post, Response, Route, SuccessResponse } from 'tsoa'
 import { Weapon, WeaponCreationParams } from '../models/weapon.model'
 import { WeaponService } from '../services/weapon.service'
 import { SuccessResponseJSON, ErrorResponseJSON } from '../types/Response.type'
@@ -26,20 +26,20 @@ export class WeaponController extends Controller {
 
     /**
      * Get the details of a specific weapon by Mongo ID.
-     * @param id Mongo ObjectID of the desired weapon
+     * @param weaponId Mongo ObjectID of the desired weapon
      */
     @SuccessResponse(200, 'Success')
     @Response<ErrorResponseJSON>(400, 'Validation Failed')
     @Response<ErrorResponseJSON>(404, 'Weapon Not Found')
     @Response<ErrorResponseJSON>(500, 'Internal Server Error')
-    @Get('{id}')
-    public async getWeapon(@Path() id: string): Promise<SuccessResponseJSON<Weapon>> {
+    @Get('{weaponId}')
+    public async getWeapon(@Path() weaponId: string): Promise<SuccessResponseJSON<Weapon>> {
         this.setStatus(200)
-        return { result: await this.service.inspectWeapon(id) }
+        return { result: await this.service.inspectWeapon(weaponId) }
     }
 
     /**
-     * Creates a weapon.
+     * Create a weapon.
      * Supply the name, description, and attack die count/sides.
      * The name must be unique, or else you will receive an error.
      * Returns the created weapon.
@@ -52,5 +52,16 @@ export class WeaponController extends Controller {
     public async postWeapon(@Body() requestBody: WeaponCreationParams): Promise<SuccessResponseJSON<Weapon>> {
         this.setStatus(201)
         return { result: await this.service.createWeapon(requestBody) }
+    }
+
+    /**
+     * Delete a given weapon from the database.
+     * It will be removed permanently - you won't be able to get it back!
+     * @param weaponId Mongo Object ID of the desired weapon.
+     */
+    @Delete('{weaponId}')
+    public async deleteWeapon(@Path() weaponId: string): Promise<any> {
+        this.setStatus(200)
+        return { weaponId }
     }
 }

--- a/src/controllers/weapon.controller.ts
+++ b/src/controllers/weapon.controller.ts
@@ -66,6 +66,6 @@ export class WeaponController extends Controller {
     @Delete('{weaponId}')
     public async deleteWeapon(@Path() weaponId: string): Promise<any> {
         this.setStatus(200)
-        return { weaponId }
+        return { result: await this.service.removeWeapon(weaponId) }
     }
 }

--- a/src/services/weapon.service.ts
+++ b/src/services/weapon.service.ts
@@ -25,6 +25,10 @@ export class WeaponService {
         return this.model.create(weaponParams)
     }
 
+    public async removeWeapon(id: string): Promise<Weapon & Document> {
+        return this.model.findByIdAndRemove(id)
+    }
+
     private async validateNameDoesNotExist(params: WeaponCreationParams | Weapon): Promise<void> {
         const { name } = params
 

--- a/src/services/weapon.service.ts
+++ b/src/services/weapon.service.ts
@@ -27,6 +27,7 @@ export class WeaponService {
 
     public async removeWeapon(id: string): Promise<Weapon & Document> {
         validateMongoID(id)
+        await validateIdExistsInModel(id, this.model)
         return this.model.findByIdAndRemove(id)
     }
 

--- a/src/services/weapon.service.ts
+++ b/src/services/weapon.service.ts
@@ -26,6 +26,7 @@ export class WeaponService {
     }
 
     public async removeWeapon(id: string): Promise<Weapon & Document> {
+        validateMongoID(id)
         return this.model.findByIdAndRemove(id)
     }
 

--- a/test/weapons/weapon.controller.spec.ts
+++ b/test/weapons/weapon.controller.spec.ts
@@ -100,7 +100,7 @@ describe('weapon controller', () => {
     })
 
     describe('deleteWeapon', () => {
-        test.skip('returns deleted weapon inside result', async () => {
+        test('returns deleted weapon inside result', async () => {
             const controller = new WeaponController()
             const weaponParams: WeaponCreationParams = {
                 name: `Weapon_${Math.random()}`,

--- a/test/weapons/weapon.controller.spec.ts
+++ b/test/weapons/weapon.controller.spec.ts
@@ -98,4 +98,24 @@ describe('weapon controller', () => {
             expect(actual.result.attackDieSides).toBe(expected.attackDieSides)
         })
     })
+
+    describe('deleteWeapon', () => {
+        test.skip('returns deleted weapon inside result', async () => {
+            const controller = new WeaponController()
+            const weaponParams: WeaponCreationParams = {
+                name: `Weapon_${Math.random()}`,
+                description: `Description_${Math.random()}`,
+                attackDieCount: 2,
+                attackDieSides: 10,
+            }
+            const expected = await createFakeWeapon(model, weaponParams)
+
+            const actual = await controller.deleteWeapon(expected._id)
+
+            expect(actual.result).toBeDefined()
+            expect(actual.result.name).toBe(expected.name)
+            expect(actual.result.description).toBe(expected.description)
+            expect(actual.result._id.toString()).toBe(expected._id.toString())
+        })
+    })
 })

--- a/test/weapons/weapon.service.spec.ts
+++ b/test/weapons/weapon.service.spec.ts
@@ -181,7 +181,14 @@ describe('weapon service', () => {
             expect(actual.description).toBe(actual.description)
         })
 
-        test.todo('throws a BadRequest error when given an invalid Mongo ID')
+        test('throws a BadRequest error when given an invalid Mongo ID', async () => {
+            const service = new WeaponService()
+            const invalidId = `invalid-id-${Math.random()}`
+            const expectedError = invalidMongoIDError(invalidId)
+
+            await expect(service.removeWeapon(invalidId)).rejects.toThrow(expectedError)
+        })
+
         test.todo('throws a NotFound error when given a valid Mongo ID that does not exist')
     })
 })

--- a/test/weapons/weapon.service.spec.ts
+++ b/test/weapons/weapon.service.spec.ts
@@ -189,6 +189,13 @@ describe('weapon service', () => {
             await expect(service.removeWeapon(invalidId)).rejects.toThrow(expectedError)
         })
 
-        test.todo('throws a NotFound error when given a valid Mongo ID that does not exist')
+        test('throws a NotFound error when given a valid Mongo ID that does not exist', async () => {
+            const mongoId = new ObjectId().toString()
+            const expectedError = notFoundError(mongoId)
+
+            const service = new WeaponService()
+
+            await expect(service.removeWeapon(mongoId)).rejects.toThrow(expectedError)
+        })
     })
 })

--- a/test/weapons/weapon.service.spec.ts
+++ b/test/weapons/weapon.service.spec.ts
@@ -140,4 +140,48 @@ describe('weapon service', () => {
             await expect(service.createWeapon(createParams)).rejects.toThrow(expectedError)
         })
     })
+
+    describe('removeWeapon', () => {
+        test('happy path - removes weapon from database', async () => {
+            const service = new WeaponService()
+            const weaponParams: WeaponCreationParams = {
+                name: `Weapon_${Math.random()}`,
+                description: `Description_${Math.random()}`,
+                attackDieCount: 2,
+                attackDieSides: 8,
+            }
+
+            const weapon = await createFakeWeapon(model, weaponParams)
+
+            const before = await model.findById(weapon._id)
+            expect(before._id.toString()).toBe(weapon._id.toString())
+            expect(before.name).toBe(weapon.name)
+
+            await service.removeWeapon(weapon._id)
+            const after = await model.findById(weapon._id)
+            expect(after).toBeFalsy()
+        })
+
+        test('happy path - returns removed weapon', async () => {
+            const service = new WeaponService()
+            const weaponParams: WeaponCreationParams = {
+                name: `Weapon_${Math.random()}`,
+                description: `Description_${Math.random()}`,
+                attackDieCount: 2,
+                attackDieSides: 8,
+            }
+
+            const expected = await createFakeWeapon(model, weaponParams)
+
+            const actual = await service.removeWeapon(expected._id)
+
+            expect(actual).toBeTruthy()
+            expect(actual._id.toString()).toBe(expected._id.toString())
+            expect(actual.name).toBe(expected.name)
+            expect(actual.description).toBe(actual.description)
+        })
+
+        test.todo('throws a BadRequest error when given an invalid Mongo ID')
+        test.todo('throws a NotFound error when given a valid Mongo ID that does not exist')
+    })
 })


### PR DESCRIPTION
### Summary
I need the ability to delete weapons from the database via API.

If accepted, this PR will:
- Creates a route to delete weapons via the API

### To Test
1. Run `yarn && yarn start`
1. Get the Mongo ID of a weapon in the database
1. Send a DELETE request to http://localhost:8000/v1/weapons/<weaponId>
1. Check your database - that weapon should no longer exist
